### PR TITLE
Add support for private cloud deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ knife[:oraclecloud_domain]   = 'my_identity_domain'
 knife oraclecloud command --oraclecloud-username myuser ...
 ```
 
+### Using with a Oracle Cloud private cloud endpoint
+
+If you are running a deployment of Oracle Cloud behind your firewall, you need to indicate that the API endpoint is a private cloud endpoint. This is required due to the differences in how the identity domain is used in their public cloud vs. their private cloud.
+
+To indicate you are using a private cloud, set the following in your knife.rb:
+
+```ruby
+knife[:oraclecloud_private_cloud] = true
+```
+
+... or simply pass `--oraclecloud-private-cloud` on the CLI.
+
 ## Usage
 
 ### knife oraclecloud server create (options)

--- a/lib/chef/knife/cloud/oraclecloud_service.rb
+++ b/lib/chef/knife/cloud/oraclecloud_service.rb
@@ -40,6 +40,7 @@ class Chef
           @verify_ssl      = options[:verify_ssl]
           @wait_time       = options[:wait_time]
           @refresh_time    = options[:refresh_time]
+          @private_cloud   = options[:private_cloud]
         end
 
         def connection
@@ -48,7 +49,8 @@ class Chef
             identity_domain: @identity_domain,
             username:        @username,
             password:        @password,
-            verify_ssl:      @verify_ssl
+            verify_ssl:      @verify_ssl,
+            private_cloud:   @private_cloud
           )
         end
 

--- a/lib/chef/knife/cloud/oraclecloud_service_helpers.rb
+++ b/lib/chef/knife/cloud/oraclecloud_service_helpers.rb
@@ -27,6 +27,7 @@ class Chef
                                                      identity_domain: locate_config_value(:oraclecloud_domain),
                                                      wait_time:       locate_config_value(:wait_time),
                                                      refresh_time:    locate_config_value(:request_refresh_rate),
+                                                     private_cloud:   locate_config_value(:oraclecloud_private_cloud),
                                                      verify_ssl:      verify_ssl?)
         end
 

--- a/lib/chef/knife/cloud/oraclecloud_service_options.rb
+++ b/lib/chef/knife/cloud/oraclecloud_service_options.rb
@@ -45,6 +45,12 @@ class Chef
               boolean:     true,
               default:     false
 
+            option :oraclecloud_private_cloud,
+              long:        '--oraclecloud-private-cloud',
+              description: 'Indicate the --oraclecloud-api-url is a private cloud endpoint',
+              boolean:     true,
+              default:     false
+
             option :request_refresh_rate,
               long:        '--request-refresh-rate SECS',
               description: 'Number of seconds to sleep between each check of the request status, defaults to 2',

--- a/spec/unit/cloud/oraclecloud_service_helpers_spec.rb
+++ b/spec/unit/cloud/oraclecloud_service_helpers_spec.rb
@@ -41,6 +41,7 @@ describe 'Chef::Knife::Cloud::OraclecloudServiceHelpers' do
       allow(tester).to receive(:locate_config_value).with(:oraclecloud_domain).and_return('test_domain')
       allow(tester).to receive(:locate_config_value).with(:wait_time).and_return(300)
       allow(tester).to receive(:locate_config_value).with(:request_refresh_rate).and_return(5)
+      allow(tester).to receive(:locate_config_value).with(:oraclecloud_private_cloud).and_return(false)
       allow(tester).to receive(:verify_ssl?).and_return(true)
 
       expect(Chef::Knife::Cloud::OraclecloudService).to receive(:new)
@@ -50,6 +51,7 @@ describe 'Chef::Knife::Cloud::OraclecloudServiceHelpers' do
               identity_domain: 'test_domain',
               wait_time:       300,
               refresh_time:    5,
+              private_cloud:   false,
               verify_ssl:      true)
 
       tester.create_service_instance


### PR DESCRIPTION
Because the identity domain is computed differently in private
vs. public cloud, the underlying API client gem requires the user
to specify whether they are using a private cloud or not. This
change exposes the ability to do that through knife.